### PR TITLE
Use rails_helper for workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See https://github.com/rspec/rspec-rails/issues/1393.
 RSpec will automatically integrate with this gem once Rails 5 is released proper.
 Adding the gem to your `Gemfile` is sufficient.
 
-To work around the issue right now, you'll have to include the modules in your `spec_helper`.
+To work around the issue right now, you'll have to include the modules in your `rails_helper`.
 
 ```ruby
 RSpec.configure do |config|


### PR DESCRIPTION
Putting the workaround in the spec_helper results in a NameError as described in issue #6. The reason for this is that the spec_helper is loaded before Rails gets loaded. An easy fix for this is to put the workaround not in the spec_helper, but in the rails_helper. This helper gets loaded after Rails, which solves the problem.
