### PR TITLE
Add version require

### DIFF
--- a/lib/rails-controller-testing.rb
+++ b/lib/rails-controller-testing.rb
@@ -2,6 +2,7 @@ require 'active_support/lazy_load_hooks'
 require 'rails/controller/testing/test_process'
 require 'rails/controller/testing/integration'
 require 'rails/controller/testing/template_assertions'
+require 'rails/controller/testing/version'
 
 ActiveSupport.on_load(:action_controller) do
   ActionController::TestCase.send(:include, Rails::Controller::Testing::TestProcess)


### PR DESCRIPTION
I'd like to conditionally load code based on the presence and version of `rails-controller-testing`, but the `VERSION` constant is not available when the library is loaded. Adding the missing require to make it available.
