### PR TITLE
Include LICENSE file in the gem

### DIFF
--- a/rails-controller-testing.gemspec
+++ b/rails-controller-testing.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = "Extracting `assigns` and `assert_template` from ActionDispatch."
   s.license     = "MIT"
 
-  s.files = Dir["{lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+  s.files = Dir["{lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
   s.require_path = ['lib']
 


### PR DESCRIPTION
There is a typo in gemspec file in license file name, so the license text is not included in generated gem, but it is recommended for MIT to include license text also in the gems. Sending the PR to fix that.

Thanks.
