### PR TITLE
Move install hooks to an `install` method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ RSpec.configure do |config|
 end
 ```
 
+## Outside Rails
+
+For projects and gems using controller tests outside of a Rails application,
+invoke the `Rails::Controller::Testing.install` method inside your test suite
+setup to include the required modules on controller test cases.
+
+```ruby
+# test/test_helper.rb
+
+require 'rails-controller-testing'
+Rails::Controller::Testing.install
+```
+
 ## Usage
 
 ### assigns

--- a/lib/rails-controller-testing.rb
+++ b/lib/rails-controller-testing.rb
@@ -1,8 +1,3 @@
 require 'rails/controller/testing'
+require 'rails/controller/testing/railtie' if defined?(Rails::Railtie)
 require 'rails/controller/testing/version'
-
-class Rails::Controller::Testing::Railtie < Rails::Railtie
-  initializer "rails_controller_testing" do
-    Rails::Controller::Testing.install
-  end
-end

--- a/lib/rails-controller-testing.rb
+++ b/lib/rails-controller-testing.rb
@@ -1,22 +1,8 @@
-require 'active_support/lazy_load_hooks'
-require 'rails/controller/testing/test_process'
-require 'rails/controller/testing/integration'
-require 'rails/controller/testing/template_assertions'
+require 'rails/controller/testing'
 require 'rails/controller/testing/version'
 
 class Rails::Controller::Testing::Railtie < Rails::Railtie
   initializer "rails_controller_testing" do
-    ActiveSupport.on_load(:action_controller) do
-      ActionController::TestCase.include Rails::Controller::Testing::TestProcess
-      ActionController::TestCase.include Rails::Controller::Testing::TemplateAssertions
-
-      ActionDispatch::IntegrationTest.include Rails::Controller::Testing::TemplateAssertions
-      ActionDispatch::IntegrationTest.include Rails::Controller::Testing::Integration
-      ActionDispatch::IntegrationTest.include Rails::Controller::Testing::TestProcess
-    end
-
-    ActiveSupport.on_load(:action_view) do
-      ActionView::TestCase.include Rails::Controller::Testing::TemplateAssertions
-    end
+    Rails::Controller::Testing.install
   end
 end

--- a/lib/rails/controller/testing.rb
+++ b/lib/rails/controller/testing.rb
@@ -1,0 +1,25 @@
+require 'active_support/lazy_load_hooks'
+require 'rails/controller/testing/test_process'
+require 'rails/controller/testing/integration'
+require 'rails/controller/testing/template_assertions'
+
+module Rails
+  module Controller
+    module Testing
+      def self.install
+        ActiveSupport.on_load(:action_controller) do
+          ActionController::TestCase.include Rails::Controller::Testing::TestProcess
+          ActionController::TestCase.include Rails::Controller::Testing::TemplateAssertions
+
+          ActionDispatch::IntegrationTest.include Rails::Controller::Testing::TemplateAssertions
+          ActionDispatch::IntegrationTest.include Rails::Controller::Testing::Integration
+          ActionDispatch::IntegrationTest.include Rails::Controller::Testing::TestProcess
+        end
+
+        ActiveSupport.on_load(:action_view) do
+          ActionView::TestCase.include Rails::Controller::Testing::TemplateAssertions
+        end
+      end
+    end
+  end
+end

--- a/lib/rails/controller/testing/railtie.rb
+++ b/lib/rails/controller/testing/railtie.rb
@@ -1,0 +1,5 @@
+class Rails::Controller::Testing::Railtie < Rails::Railtie
+  initializer "rails_controller_testing" do
+    Rails::Controller::Testing.install
+  end
+end


### PR DESCRIPTION
I though about moving the `railtie` to it's own file with a `defined?` check for `Rails::Railtie`, so gems that use this for testing don't have to depend on `railties` to load this, so if it makes sense I can push a commit for that on this branch.
