### PR TITLE
Remove xhr and xml_http_request due to rails 5 deprecation warning

### DIFF
--- a/lib/rails/controller/testing/integration.rb
+++ b/lib/rails/controller/testing/integration.rb
@@ -3,8 +3,8 @@ module Rails
     module Testing
       module Integration
         %w(
-          get post patch put head delete xml_http_request
-          xhr get_via_redirect post_via_redirect
+          get post patch put head delete
+          get_via_redirect post_via_redirect
         ).each do |method|
 
           define_method(method) do |*args|

--- a/lib/rails/controller/testing/integration.rb
+++ b/lib/rails/controller/testing/integration.rb
@@ -2,11 +2,10 @@ module Rails
   module Controller
     module Testing
       module Integration
-        %w(
-          get post patch put head delete
-          get_via_redirect post_via_redirect
-        ).each do |method|
+        http_verbs = %w(get post patch put head delete get_via_redirect post_via_redirect)
+        http_verbs.push('xhr', 'xml_http_request') if Rails::VERSION::STRING.to_f <= 5.0
 
+        http_verbs.each do |method|
           define_method(method) do |*args|
             reset_template_assertion
             super(*args)


### PR DESCRIPTION
`DEPRECATION WARNING: `xhr` and `xml_http_request` are deprecated and will be removed in Rails 5.1.
Switch to e.g. `post :create, params: { comment: { body: 'Honey bunny' } }, xhr: true`.`