### PR TITLE
Relax version requirement and test against Rails master (6.0.0.alpha)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ gemfile:
   - Gemfile
   - gemfiles/Gemfile-rails-5-0
   - gemfiles/Gemfile-rails-5-2
+  - gemfiles/Gemfile-rails-master
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 cache: bundler
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
 gemfile:
   - Gemfile
@@ -14,6 +15,11 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   fast_finish: true
+  exclude:
+    - rvm: 2.2.10
+      gemfile: gemfiles/Gemfile-rails-master
+    - rvm: 2.3.7
+      gemfile: gemfiles/Gemfile-rails-master
 env:
   global:
     - "JRUBY_OPTS=-Xcext.enabled=true"

--- a/gemfiles/Gemfile-rails-master
+++ b/gemfiles/Gemfile-rails-master
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec path: '..'
+
+gem 'actionpack', git: "https://github.com/rails/rails.git"

--- a/rails-controller-testing.gemspec
+++ b/rails-controller-testing.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_dependency "actionpack", ">= 5.0.1", "< 6.1.x"
-  s.add_dependency "actionview", ">= 5.0.1", "< 6.1.x"
-  s.add_dependency "activesupport", ">= 5.0.1", "< 6.1.x"
+  s.add_dependency "actionpack", ">= 5.0.1.x"
+  s.add_dependency "actionview", ">= 5.0.1.x"
+  s.add_dependency "activesupport", ">= 5.0.1.x"
 
-  s.add_development_dependency "railties", "> 5.0.1", "< 6.1.x"
+  s.add_development_dependency "railties", "> 5.0.1.x"
 
   if defined?(JRUBY_VERSION)
     s.add_development_dependency "jdbc-sqlite3"

--- a/rails-controller-testing.gemspec
+++ b/rails-controller-testing.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_dependency "actionpack", "~> 5.x", ">= 5.0.1"
-  s.add_dependency "actionview", "~> 5.x", ">= 5.0.1"
-  s.add_dependency "activesupport", "~> 5.x"
+  s.add_dependency "actionpack", ">= 5.0.1", "< 6.1.x"
+  s.add_dependency "actionview", ">= 5.0.1", "< 6.1.x"
+  s.add_dependency "activesupport", ">= 5.0.1", "< 6.1.x"
 
-  s.add_development_dependency "railties", "~> 5.x"
+  s.add_development_dependency "railties", "> 5.0.1", "< 6.1.x"
 
   if defined?(JRUBY_VERSION)
     s.add_development_dependency "jdbc-sqlite3"


### PR DESCRIPTION
I'm trying to fix a [compatibility issue with rspec-rails](https://github.com/rails/rails/pull/32065#issuecomment-378798182), and looks like right now they can't even point to rails master since `rails-controller-testing` requirement does not support prerelease version.