### PR TITLE
More correct requirement specifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       gemfile: gemfiles/Gemfile-rails-master
     - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-rails-master
+    - rvm: 2.4.5
+      gemfile: gemfiles/Gemfile-rails-master
 env:
   global:
     - "JRUBY_OPTS=-Xcext.enabled=true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 cache: bundler
 rvm:
   - 2.2.10
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
   - ruby-head
 gemfile:
   - gemfiles/Gemfile-rails-5-0
@@ -18,7 +19,7 @@ matrix:
   exclude:
     - rvm: 2.2.10
       gemfile: gemfiles/Gemfile-rails-master
-    - rvm: 2.3.7
+    - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-rails-master
 env:
   global:

--- a/rails-controller-testing.gemspec
+++ b/rails-controller-testing.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_dependency "actionpack", ">= 5.0.1.x"
-  s.add_dependency "actionview", ">= 5.0.1.x"
-  s.add_dependency "activesupport", ">= 5.0.1.x"
+  s.add_dependency "actionpack", ">= 5.0.1.rc1"
+  s.add_dependency "actionview", ">= 5.0.1.rc1"
+  s.add_dependency "activesupport", ">= 5.0.1.rc1"
 
-  s.add_development_dependency "railties", "> 5.0.1.x"
+  s.add_development_dependency "railties", ">= 5.0.1.rc1"
 
   if defined?(JRUBY_VERSION)
     s.add_development_dependency "jdbc-sqlite3"


### PR DESCRIPTION
The way prereleases are designed by rubygems is the following. The first segment containing a non numeric character is considered the begining of the prerelease part of the version. For example, in "5.0.1.x", "5.0.1" is the release part, and "x" is the prerelease part (it could contain more segments, but in this case is just one). The way versions are compared is. Each of the segments in the release part (left to right) is compared to each other (assuming 0 is one of the versions don't have the segment). If every thing is the same, the prerelease parts are compared in the same way, except that segments containing non numeric characters are compared lexicographically. That means that `5.0.1.rc1` would be considered lower than `5.0.1.x`, and thus wouldn't be allowed here.

The funny part is that this currently works the way one would expect, but it's only due to what I consider a bug in rubygems. See https://github.com/rubygems/rubygems/pull/2597.