### PR TITLE
Allow assert_template(file:) to work using Rails 6

### DIFF
--- a/lib/rails/controller/testing.rb
+++ b/lib/rails/controller/testing.rb
@@ -2,6 +2,7 @@ require 'active_support/lazy_load_hooks'
 require 'rails/controller/testing/test_process'
 require 'rails/controller/testing/integration'
 require 'rails/controller/testing/template_assertions'
+require 'rails/controller/testing/template_instrumentation'
 
 module Rails
   module Controller
@@ -10,16 +11,19 @@ module Rails
         ActiveSupport.on_load(:action_controller_test_case) do
           include Rails::Controller::Testing::TestProcess
           include Rails::Controller::Testing::TemplateAssertions
+          ActionView::TemplateRenderer.prepend(InstrumentDetermineTemplate)
         end
 
         ActiveSupport.on_load(:action_dispatch_integration_test) do
           include Rails::Controller::Testing::TemplateAssertions
           include Rails::Controller::Testing::Integration
           include Rails::Controller::Testing::TestProcess
+          ActionView::TemplateRenderer.prepend(InstrumentDetermineTemplate)
         end
 
         ActiveSupport.on_load(:action_view_test_case) do
           include Rails::Controller::Testing::TemplateAssertions
+          ActionView::TemplateRenderer.prepend(InstrumentDetermineTemplate)
         end
       end
     end

--- a/lib/rails/controller/testing/template_assertions.rb
+++ b/lib/rails/controller/testing/template_assertions.rb
@@ -30,6 +30,16 @@ module Rails
             end
           end
 
+          @_subscribers << ActiveSupport::Notifications.subscribe("determine_template.rails_controller_testing") do |_name, _start, _finish, _id, payload|
+            if payload[:options][:file]
+              path = payload[:template_identifier]
+              if path
+                @_files[path] += 1
+                @_files[path.split("/").last] += 1
+              end
+            end
+          end
+
           @_subscribers << ActiveSupport::Notifications.subscribe("!render_template.action_view") do |_name, _start, _finish, _id, payload|
             if virtual_path = payload[:virtual_path]
               partial = virtual_path =~ /^.*\/_[^\/]*$/
@@ -40,12 +50,6 @@ module Rails
               end
 
               @_templates[virtual_path] += 1
-            else
-              path = payload[:identifier]
-              if path
-                @_files[path] += 1
-                @_files[path.split("/").last] += 1
-              end
             end
           end
         end

--- a/lib/rails/controller/testing/template_instrumentation.rb
+++ b/lib/rails/controller/testing/template_instrumentation.rb
@@ -1,0 +1,16 @@
+module Rails
+  module Controller
+    module Testing
+      module InstrumentDetermineTemplate
+        def determine_template(options)
+          super.tap do |found|
+            if found
+              instrument_payload = { template_identifier: found.identifier, virtual_path: found.virtual_path, options: options }
+              ActiveSupport::Notifications.instrument("determine_template.rails_controller_testing", instrument_payload)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Note:** There may be a better way to approach this or ways to address some of my concerns below. I'd be very happy to get any feedback / suggestions on improving this.

An `ActionView::Template`'s `virtual_path` is deprecated under Rails 6. This commit:

https://github.com/rails/rails/commit/9a343d148b96874a231b87906c9d6499b5e0b64a#diff-40f2a5bcf9edfd65a8efe42a05c53736L437

causes the virtual path for templates rendered using `file:` to no longer have their `virtual_path` explicitly set to `nil`. `rails-controller-testing` uses the absence of the `virtual_path` attribute to indicate that the template was rendered as using `file:`. See:

https://github.com/rails/rails-controller-testing/blob/master/lib/rails/controller/testing/template_assertions.rb#L34

Because the attribute is never nil with Rails 6, the ability to test something like `assert_template(file: "#{Rails.root}/public/404.html")` is broken.

This commit changes the way rendered `file:` templates are tracked. Instead of paying attention to calls to `ActionView::Template#render` ( subscribing to`"!render_template.action_view"`) this update instead focuses on `ActionView::TemplateRenderer#determine_template`. Because `determine_tempalte` is not already instrumented, we need to provide our own instrumentation by redefining the method, adding instrumentation, and then handing off to `super`.

**Concerns**

This probably is not ideal for at least a few reasons:

* `determine_template` is a few steps removed from `ActionView::Template#render` but is the last place in which we have information about what template is being rendered *and* whether or not it was rendered as a `file:`.

* This method overrides `ActionView::TemplateRenderer#determine_template` for all tests, regardless of whether or not file assertions are required. It would be better if the overriding module was prepended only when necessary and removed afterward.

* The testing logic applied to `file:` templates is different than for other template types. I'm not extremely happy about that, but given that `ActionView::Template#render` is probably a *better* place to be watching, the change only applies to file templates, not partials, etc...

**Testing:**

All _current tests_ continue to pass, but this is running against a Rails 5 dummy application so the Rails 6 issue isn't actually tested. The fix worked in our test suite running against a Rails 6 application, but it may be that a Rails 6 branch of `rails_controller_testing` with an upgraded dummy app is in order? (I'm not sure what's best there.)