### PR TITLE
Avoid deprecated dynamic controller/action segment

### DIFF
--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -7,10 +7,8 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # We need eager_load to create our test routes dynamically.
+  config.eager_load = true
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
-  get ':controller(/:action)'
+  ActionController::Base.descendants.each do |controller|
+    controller.action_methods.each do |action|
+      get "#{controller.controller_name}/#{action}"
+    end
+  end
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
The dynamic :controller and :action segments are removed from the route
configurations in Rails 6.1.

This commit updates the routing configuration for the tests to avoid the
deprecation warnings while still generating routes dynamically.