### PR TITLE
Fix kwargs usage for Ruby 2.7

### DIFF
--- a/lib/rails/controller/testing/integration.rb
+++ b/lib/rails/controller/testing/integration.rb
@@ -4,13 +4,23 @@ module Rails
   module Controller
     module Testing
       module Integration
-        http_verbs = %w(get post patch put head delete get_via_redirect post_via_redirect)
-        http_verbs.push('xhr', 'xml_http_request') if ActionPack.version < Gem::Version.new('5.1')
+        http_verbs = %w(get post patch put head delete)
+
+        if ActionPack.version < Gem::Version.new('5.1')
+          http_verbs.push('xhr', 'xml_http_request', 'get_via_redirect', 'post_via_redirect')
+        end
 
         http_verbs.each do |method|
-          define_method(method) do |*args|
-            reset_template_assertion
-            super(*args)
+          if ActionPack.version < Gem::Version.new('5.1')
+            define_method(method) do |path, *args|
+              reset_template_assertion
+              super(path, *args)
+            end
+          else
+            define_method(method) do |path, **args|
+              reset_template_assertion
+              super(path, **args)
+            end
           end
         end
       end

--- a/lib/rails/controller/testing/template_assertions.rb
+++ b/lib/rails/controller/testing/template_assertions.rb
@@ -56,9 +56,9 @@ module Rails
           end
         end
 
-        def process(*args)
+        def process(action, **options)
           reset_template_assertion
-          super
+          super(action, **options)
         end
 
         def reset_template_assertion


### PR DESCRIPTION
This PR intend to fix Ruby 2.7 deprecation warning:

```
gems/rails-controller-testing-1.0.4/lib/rails/controller/testing/integration.rb:13: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

I've add a second `**options` args to keep symmetry with `actionpack/lib/action_dispatch/testing/integration.rb:352` 