### PR TITLE
teardown_subscriptions: Avoid NoMethodError on nil

### DIFF
--- a/lib/rails/controller/testing/template_assertions.rb
+++ b/lib/rails/controller/testing/template_assertions.rb
@@ -51,7 +51,7 @@ module Rails
         end
 
         def teardown_subscriptions
-          @_subscribers.each do |subscriber|
+          @_subscribers && @_subscribers.each do |subscriber|
             ActiveSupport::Notifications.unsubscribe(subscriber)
           end
         end


### PR DESCRIPTION
In case e.g. a Webpacker configuration issue raised an early error, `@_subscribers` may be nil.

## Background

Here's what my configuration error output looked like: a RuntimeError was raised just before this.

```
195.2) Failure/Error:
        @_subscribers.each do |subscriber|
          ActiveSupport::Notifications.unsubscribe(subscriber)
        end

      NoMethodError:
        undefined method `each' for nil:NilClass

      # /home/circleci/project/vendor/bundle/ruby/2.6.0/gems/rails-controller-testing-1.0.4/lib/rails/controller/testing/template_assertions.rb:54:in `teardown_subscriptions'
      # /home/circleci/project/vendor/bundle/ruby/2.6.0/gems/rspec-rails-4.0.0/lib/rspec/rails/adapters.rb:124:in `block (2 levels) in teardown'
```

## Solution

Ensure the list is a list before trying to use it.