### PR TITLE
CI: Use rails as git gem with branch 5-2-stable in Gemfile-rails-5-2  to support Ruby 2.2.10

### DIFF
--- a/gemfiles/Gemfile-rails-5-2
+++ b/gemfiles/Gemfile-rails-5-2
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 gemspec path: '..'
 
-gem 'actionpack', '~> 5.2.0'
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
+gem 'actionpack', '~> 5.2.0', github: 'rails/rails', branch: '5-2-stable'


### PR DESCRIPTION
This PR fixes the build (for Rails 5.2 with Ruby 2.2).

2.2.10 does not have safe navigation which is used in the published 5.2 gems.

## Background

Example error message:

```
/home/travis/build/rails/rails-controller-testing/gemfiles/vendor/bundle/ruby/2.2.0/gems/actionpack-5.2.4.2/lib/action_dispatch/request/session.rb:96: syntax error, unexpected '.' (SyntaxError)
          id&.public_id
              ^
```

Using the safe-navigation-free `5-2-stable` branch from git fixes it.

Rafael taught me this, in another repo. Thanks for that!

## Solution

- Use a git branch version supporting 2.2
- Note: the other build errors are actual test failures