### PR TITLE
(chore) Git ignore lockfiles in gemfiles/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/dummy/tmp/
 test/dummy/.sass-cache
 *.gem
 Gemfile.lock
+gemfiles/*.lock


### PR DESCRIPTION
This PR adds an ignore pattern to help developers not commit lockfiles for the gemfiles/ directory either.

We already had a pattern for the root `Gemfile.lock`.