### PR TITLE
Remove deprecation warning for Ruby 2.7

### DIFF
--- a/lib/rails/controller/testing/template_assertions.rb
+++ b/lib/rails/controller/testing/template_assertions.rb
@@ -58,7 +58,9 @@ module Rails
 
         def process(*args)
           reset_template_assertion
-          super
+          action = args[0]
+          params = args[1] || {}
+          super(action, **params)
         end
 
         def reset_template_assertion


### PR DESCRIPTION
Ruby 2.7 has deprecated passing the last argument as a keyword parameter. https://bugs.ruby-lang.org/issues/14183

Fixes the following
```
/rails-controller-testing/lib/rails/controller/testing/template_assertions.rb:61: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/rails/actionpack/lib/action_controller/test_case.rb:460: warning: The called method `process' is defined here
```

The fix is backwards compatible with Ruby < 2.7