### PR TITLE
Not pass empty kwargs to ActionPack

### DIFF
--- a/lib/rails/controller/testing/integration.rb
+++ b/lib/rails/controller/testing/integration.rb
@@ -13,7 +13,11 @@ module Rails
         http_verbs.each do |method|
           define_method(method) do |*args, **kwargs|
             reset_template_assertion
-            super(*args, **kwargs)
+            if kwargs == {}
+              super(*args)
+            else
+              super(*args, **kwargs)
+            end
           end
         end
       end


### PR DESCRIPTION
Empty kwargs occur in simple calls without any parameters or headers, e.g. `get '/some/path`. Code added in #58 passes empty kwargs in the form of an empty hash to  ActionPack that considers it not to be compatible with the new kwargs-style syntax and emits a useless deprecation warning.