### PR TITLE
Disable relative template test cases

### DIFF
--- a/test/controllers/template_assertions_test.rb
+++ b/test/controllers/template_assertions_test.rb
@@ -13,6 +13,8 @@ class TemplateAssertionsControllerTest < ActionController::TestCase
   end
 
   def test_file_with_relative_path_success
+    skip "Deprecated in ActionPack 6.1+" if ActionPack.version >= Gem::Version.new('6.1')
+
     get :render_file_relative_path
     assert_template file: 'README.rdoc'
   end
@@ -179,8 +181,10 @@ class TemplateAssertionsControllerTest < ActionController::TestCase
     get :render_nothing
     assert_template layout: nil
 
-    get :render_file_relative_path
-    assert_template file: 'README.rdoc'
+    if ActionPack.version < Gem::Version.new('6.1')
+      get :render_file_relative_path
+      assert_template file: 'README.rdoc'
+    end
 
     get :render_nothing
     assert_template file: nil

--- a/test/integration/template_assertions_test.rb
+++ b/test/integration/template_assertions_test.rb
@@ -26,6 +26,8 @@ class TemplateAssertionsIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def test_file_reset_between_requests
+    skip "Deprecated in ActionPack 6.1+" if ActionPack.version >= Gem::Version.new('6.1')
+
     get '/template_assertions/render_file_relative_path'
     assert_template file: 'README.rdoc'
 
@@ -64,6 +66,8 @@ class TemplateAssertionsIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def test_file_reset_between_requests_when_opening_a_session
+    skip "Deprecated in ActionPack 6.1+" if ActionPack.version >= Gem::Version.new('6.1')
+
     open_session do |session|
       session.get '/template_assertions/render_file_relative_path'
       session.assert_template file: 'README.rdoc'


### PR DESCRIPTION
This is naive attempt to fix the test suite for Rails 6.1.

Fixes #64