### PR TITLE
Add identifier option to #render_template

### DIFF
--- a/test/controllers/template_assertions_test.rb
+++ b/test/controllers/template_assertions_test.rb
@@ -160,6 +160,27 @@ class TemplateAssertionsControllerTest < ActionController::TestCase
     assert_template layout: :standard
   end
 
+  def test_identifier
+    get :render_with_template
+    assert_template identifier: Rails.root.join('app/views/test/hello_world.html.erb').to_s
+  end
+
+  def test_identifier_with_layout
+    get :render_with_layout
+    assert_template identifier: Rails.root.join('app/views/layouts/standard.html.erb').to_s
+  end
+
+  def test_identifier_with_partial
+    get :render_with_partial
+    assert_template identifier: Rails.root.join('app/views/test/_partial.html.erb').to_s
+  end
+
+  def test_identifier_with_layout_and_partial
+    get :render_with_layout_and_partial
+    assert_template identifier: Rails.root.join('app/views/layouts/standard.html.erb').to_s
+    assert_template identifier: Rails.root.join('app/views/test/_partial.html.erb').to_s
+  end
+
   def test_assert_template_reset_between_requests
     get :render_with_template
     assert_template 'test/hello_world'


### PR DESCRIPTION
In my Rails app, I needed to write a test that distinguishes whether a template for smartphone (e.g. app/views/articles/index.html+smartphone.erb) or one for PC (e.g. app/views/articles/index.html.erb) was rendered, but I couldn't write such test with the current rails-controller-testing implementation. This is because it only provides virtual_path (e.g. articles/index), which doesn't contain the variants information.

I'd like to add a new option `identifier` to be able to write these kinds of tests.