### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,3 @@ matrix:
     - rvm: 2.6.5
       gemfile: gemfiles/Gemfile-rails-main
   fast_finish: true
-env:
-  global:
-    - "JRUBY_OPTS=-Xcext.enabled=true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
 gemfile:
   - gemfiles/Gemfile-rails-5-2
   - gemfiles/Gemfile-rails-6-0
-  - gemfiles/Gemfile-rails-master
+  - gemfiles/Gemfile-rails-main
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ gemfile:
   - gemfiles/Gemfile-rails-main
 matrix:
   allow_failures:
+    - gemfile: gemfiles/Gemfile-rails-main
     - rvm: ruby-head
   exclude:
     - rvm: 2.5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: ruby-head
+  exclude:
+    - rvm: 2.5.3
+      gemfile: gemfiles/Gemfile-rails-main
+    - rvm: 2.6.5
+      gemfile: gemfiles/Gemfile-rails-main
   fast_finish: true
 env:
   global:

--- a/gemfiles/Gemfile-rails-main
+++ b/gemfiles/Gemfile-rails-main
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec path: '..'
+
+gem 'actionpack', git: "https://github.com/rails/rails.git", branch: 'main'

--- a/gemfiles/Gemfile-rails-master
+++ b/gemfiles/Gemfile-rails-master
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-gemspec path: '..'
-
-gem 'actionpack', git: "https://github.com/rails/rails.git"


### PR DESCRIPTION
Rails changed its default branch from `master` to `main`, so I added `branch: 'main'` to Gemfile.

- <https://github.com/rails/rails/commit/077c66d5d6ef3a6f1cc54e4a431bfa5ea6831b97>

Ruby 2.5 and 2.6 are no longger supported by Rails 7.0.0.alpha2, which is fetched from its `main` branch, so I excluded this combination.

In addition, I added `gemfile: gemfiles/Gemfile-rails-main` to `allowed_failures` as we do for ruby-head. We're not sure what will happen with the latest version of Rails.