### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ end
 
 ### assert_template
 
-`assert_template` allows to you assert that certain templates have been rendered.
+`assert_template` allows you to assert that certain templates have been rendered.
 
 ```ruby
 class PostControllerTest < ActionController::TestCase


### PR DESCRIPTION
Signed-off-by: Marcus Heng <marcushwz@gmail.com>

I was looking into this gem and found a typo in the README.