### PR TITLE
Fix assert_template(file:) with Rails 6

### DIFF
--- a/lib/rails/controller/testing.rb
+++ b/lib/rails/controller/testing.rb
@@ -2,6 +2,7 @@ require 'active_support/lazy_load_hooks'
 require 'rails/controller/testing/test_process'
 require 'rails/controller/testing/integration'
 require 'rails/controller/testing/template_assertions'
+require 'rails/controller/testing/instrument_determine_template'
 
 module Rails
   module Controller
@@ -16,6 +17,12 @@ module Rails
           include Rails::Controller::Testing::TemplateAssertions
           include Rails::Controller::Testing::Integration
           include Rails::Controller::Testing::TestProcess
+        end
+
+        if ActiveSupport::VERSION::MAJOR >= 6
+          ActiveSupport.on_load(:action_view) do
+            ActionView::TemplateRenderer.prepend(InstrumentDetermineTemplate)
+          end
         end
 
         ActiveSupport.on_load(:action_view_test_case) do

--- a/lib/rails/controller/testing/instrument_determine_template.rb
+++ b/lib/rails/controller/testing/instrument_determine_template.rb
@@ -1,0 +1,18 @@
+module Rails
+  module Controller
+    module Testing
+      module InstrumentDetermineTemplate
+        def determine_template(options)
+          super.tap do |template|
+            if template.is_a?(ActionView::Template::RawFile)
+              ActiveSupport::Notifications.instrument(
+                "!render_template.action_view",
+                { virtual_path: nil, identifier: template.identifier }
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
 * Brings back `!render_template.action_view` instrumentation when rendering with ActionView::Template::RawFile

See https://github.com/rails/rails-controller-testing/pull/46 for discussion.

Note that all I did was rebase the work of @tconst onto the newest commit of [rails-controller-testing](https://github.com/rails/rails-controller-testing).